### PR TITLE
fix clang compile issues (#109)

### DIFF
--- a/scanners/iat_scanner.h
+++ b/scanners/iat_scanner.h
@@ -62,7 +62,7 @@ namespace pesieve {
 	class IATScanner : public ModuleScanner {
 	public:
 
-		IATScanner::IATScanner(
+		IATScanner(
 			HANDLE hProc,
 			ModuleData &moduleData,
 			RemoteModuleData &remoteModData,

--- a/scanners/module_data.cpp
+++ b/scanners/module_data.cpp
@@ -257,7 +257,7 @@ std::string pesieve::RemoteModuleData::getModuleName(HANDLE processHandle, HMODU
 std::string pesieve::RemoteModuleData::getMappedName(HANDLE processHandle, LPVOID modBaseAddr)
 {
 	char filename[MAX_PATH] = { 0 };
-	if (!GetMappedFileNameA(processHandle, modBaseAddr, filename, MAX_PATH) != 0) {
+	if (GetMappedFileNameA(processHandle, modBaseAddr, filename, MAX_PATH) == 0) {
 		return "";
 	}
 	std::string expanded = pesieve::util::expand_path(filename);

--- a/scanners/thread_scanner.cpp
+++ b/scanners/thread_scanner.cpp
@@ -3,7 +3,7 @@
 #include "../utils/process_util.h"
 #include "../utils/ntddk.h"
 
-#include <DbgHelp.h>
+#include <dbghelp.h>
 #pragma comment(lib, "dbghelp")
 
 using namespace pesieve;

--- a/utils/format_util.cpp
+++ b/utils/format_util.cpp
@@ -82,7 +82,7 @@ bool pesieve::util::is_in_list(std::string searched_str, std::set<std::string>& 
 {
 	bool result = false;
 	if (to_lower) {
-		std::transform(searched_str.begin(), searched_str.end(), searched_str.begin(), std::tolower);
+		std::transform(searched_str.begin(), searched_str.end(), searched_str.begin(), [](unsigned char c){ return std::tolower(c); });
 	}
 	std::set<std::string>::iterator found = string_list.find(searched_str);
 	if (found != string_list.end()) {
@@ -124,7 +124,7 @@ size_t pesieve::util::string_to_list(IN::std::string s, IN char _delim, OUT::std
 		trim(next_str);
 		if (next_str.length() > 0) {
 			if (to_lower) {
-				std::transform(next_str.begin(), next_str.end(), next_str.begin(), std::tolower);
+				std::transform(next_str.begin(), next_str.end(), next_str.begin(), [](unsigned char c){ return std::tolower(c); });
 			}
 			elements_list.insert(next_str);
 		}
@@ -135,7 +135,7 @@ size_t pesieve::util::string_to_list(IN::std::string s, IN char _delim, OUT::std
 	trim(next_str);
 	if (next_str.length() > 0) {
 		if (to_lower) {
-			std::transform(next_str.begin(), next_str.end(), next_str.begin(), std::tolower);
+			std::transform(next_str.begin(), next_str.end(), next_str.begin(), [](unsigned char c){ return std::tolower(c); });
 		}
 		elements_list.insert(next_str);
 	}

--- a/utils/path_converter.cpp
+++ b/utils/path_converter.cpp
@@ -158,7 +158,7 @@ namespace pesieve {
 							size_t dir_len = strlen(pch);
 							//if so, cut out the mappining path/device path and replace it with a drive letter
 							std::string str2 = full_path.substr(dir_len, full_path_size);
-							if (str2[0] != '//' && str2[0] != '\\') {
+							if (str2[0] != '/' && str2[0] != '\\') {
 								str2 = "\\" + str2;
 							}
 							return letter + str2;

--- a/utils/process_privilege.cpp
+++ b/utils/process_privilege.cpp
@@ -6,7 +6,7 @@
 namespace pesieve {
 	namespace util {
 
-		inline HMODULE get_or_load_module(char* name)
+		inline HMODULE get_or_load_module(const char* name)
 		{
 			HMODULE hndl = GetModuleHandleA(name);
 			if (!hndl) {

--- a/utils/process_reflection.cpp
+++ b/utils/process_reflection.cpp
@@ -188,7 +188,7 @@ namespace pesieve {
 			if (ret == S_OK) {
 				args->is_ok = true;
 				args->returned_hndl = info.ReflectionProcessHandle;
-				args->returned_pid = (DWORD)info.ReflectionClientId.UniqueProcess;
+				args->returned_pid = static_cast<DWORD>(reinterpret_cast<uintptr_t>(info.ReflectionClientId.UniqueProcess));
 			}
 			return ret;
 		}


### PR DESCRIPTION
* fix: include headers as lower case

* fix: resolve template confusion with overloaded std::tolower()

std::tolower is overloaded, which caused mingw-gcc to not correctly
deduce the template parameter, leading to a compilation error.
Wrap std::tolower in a lambda that explicitly states the input
parameters.

* chore: don't use class:: prefix in inline definition

* chore: explicit cast from pointer to smaller integer type

* chore: single character constant for /

* chore: pass string as const char*

* chore: simplify if condition